### PR TITLE
Added a traverse function for B+ trees

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -78,6 +78,24 @@ bc. (bplustree-delete 32 *my-tree*)
 (bplustree-search-range 0 1000 *my-tree*)
 ("5" "10" "52" "100" "212" "311")
 
+
+h3. @(bplustree-traverse (tree fn))@
+
+Traverses all records in the tree in order from smallest to largest. As the B+ trees store data sorted already this operation is not expensive.
+
+Example:
+
+bc. (bplustree-traverse *my-tree* 'print)
+"-1"
+"5"
+"10"
+"32"
+"52"
+"212"
+"311"
+"1337"
+
+
 h2. Final remarks
 
 I hope this code is useful to you in any sense, either for learning, reading or maybe actual practical use, I will be very glad if you can even modify it to suit your needs. If you have suggestions please send them my way. Be sure to read *COPYING* file as well.

--- a/bplustree.lisp
+++ b/bplustree.lisp
@@ -6,6 +6,12 @@
 (defstruct bplustree root depth order key comparer)
 (defstruct node kind order size keys records next-node)
 
+(defmethod print-object ((tree bplustree) str)
+  (print-unreadable-object (tree str :identity t)
+    (princ "B+ TREE" str)
+    (princ ": " str)
+    (princ (bplustree-depth tree) str)))
+
 (defmacro build-node-collection-accesors (column)
   "Generates the getter/setter functions for the btreeplus-node internal collections, keys and records."
   (let* ((package (symbol-package column))
@@ -304,3 +310,15 @@
           (setf (bplustree-root tree) (node-record root 0))
           (decf (bplustree-depth tree)))
         tree))))
+
+(defun bplustree-traverse-node (node fn)
+  (cond ((null node))
+        ((node-internal-p node)
+         (loop for node across (node-records node)
+            do (bplustree-traverse-node node fn)))
+        (t (map nil (lambda (v)
+                      (when v
+                        (funcall fn v))) (node-records node)))))
+
+(defun bplustree-traverse (tree fn)
+  (bplustree-traverse-node (bplustree-root tree) fn))

--- a/packages.lisp
+++ b/packages.lisp
@@ -11,4 +11,5 @@
    :bplustree-search-range
    :bplustree-insert
    :bplustree-insert-many
-   :bplustree-delete))
+   :bplustree-delete
+   :bplustree-traverse))


### PR DESCRIPTION
In addition to traverse function, this change contains a PRINT-OBJECT method for BPLUSTREE. It is necessary, as for large trees the default version chokes the stream.