### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/cl-bplustree.asd
+++ b/cl-bplustree.asd
@@ -3,20 +3,18 @@
 
 ;;; cl-bplustree.asd
 
-(asdf:defsystem #:cl-bplustree
-  :name "cl-bplustree"
+(defsystem #:cl-bplustree
   :author "Francisco Soto <ebobby@ebobby.org>"
   :license "BSD"
   :description "In-memory B+ tree"
   :components ((:file "packages")
                (:file "bplustree" :depends-on ("packages")))
-  :in-order-to ((asdf:test-op
-                 (asdf:test-op #:cl-bplustree-test))))
+  :in-order-to ((test-op
+                 (test-op #:cl-bplustree/test))))
 
-(asdf:defsystem #:cl-bplustree-test
-  :name "cl-bplustree-test"
+(defsystem #:cl-bplustree/test
   :depends-on (#:cl-bplustree)
   :components
   ((:file "test"))
-  :perform (asdf:test-op (op c)
-              (funcall (intern #.(string '#:bplustree-test) :org.ebobby.bplustree))))
+  :perform (test-op (op c)
+              (symbol-call :org.ebobby.bplustree :bplustree-test)))


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
